### PR TITLE
Fix "Can I use" links for JS entities

### DIFF
--- a/features.yml
+++ b/features.yml
@@ -707,32 +707,32 @@
 - id: page_visibility
   name: Page Visibility API
   mdn: /en-US/docs/Web/API/Page_Visibility_API
-  caniuse: /pagevisibility
+  caniuse: pagevisibility
 
 - id: broadcast_channel
   name: Broadcast Channel API
   mdn: /en-US/docs/Web/API/Broadcast_Channel_API
-  caniuse: /broadcastchannel
+  caniuse: broadcastchannel
 
 - id: geolocation
   name: Geolocation API
   mdn: /en-US/docs/Web/API/Geolocation_API
-  caniuse: /geolocation
+  caniuse: geolocation
   
 - id: file_system_access
   name: File System Access API
   mdn: /en-US/docs/Web/API/File_System_Access_API
-  caniuse: /native-filesystem-api
+  caniuse: native-filesystem-api
   
 - id: web_share
   name: Web Share API
   mdn: /en-US/docs/Web/API/Web_Share_API
-  caniuse: /web-share
+  caniuse: web-share
   
 - id: webxr
   name: WebXR Device API
   mdn: /en-US/docs/Web/API/WebXR_Device_API
-  caniuse: /webxr
+  caniuse: webxr
   
   
 # Other Features
@@ -793,27 +793,27 @@
 - id: string_replace_all
   name: String.prototype.replaceAll()
   mdn: /en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll
-  caniuse: /mdn-javascript_builtins_string_replaceall
+  caniuse: mdn-javascript_builtins_string_replaceall
 
 - id: string_match_all
   name: String.prototype.matchAll()
   mdn: /en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
-  caniuse: /mdn-javascript_builtins_string_matchall
+  caniuse: mdn-javascript_builtins_string_matchall
 
 - id: logical_assignment
   name: Logical Assignment
   mdn: /en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment
-  caniuse: /mdn-javascript_operators_logical_and_assignment
+  caniuse: mdn-javascript_operators_logical_and_assignment
 
 - id: promise_any
   name: Promise.any()
   mdn: /en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any
-  caniuse: /mdn-javascript_builtins_promise_any
+  caniuse: mdn-javascript_builtins_promise_any
 
 - id: array_at
   name: Array.prototype.at()
   mdn: /en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at
-  caniuse: /mdn-javascript_builtins_array_at
+  caniuse: mdn-javascript_builtins_array_at
 
 - id: top_level_await
   name: Top Level Await


### PR DESCRIPTION
Fix broken "Can I Use" links like https://caniuse.com//pagevisibility, whereas should be https://caniuse.com/pagevisibility