### PR TITLE
Link Exclusive Accordion to web-features id

### DIFF
--- a/entities/features/html_features/features_html.yml
+++ b/entities/features/html_features/features_html.yml
@@ -5,6 +5,7 @@
 #################################################
 
 - id: accordion_element
+  webFeaturesId: details-name
   name: Exclusive Accordion
   needsTranslation: true
   description:
@@ -35,7 +36,6 @@
       title: Chrome Platform Status
   tags:
     - features
-    - web-features:details-name
   patterns:
     - accordion
 

--- a/entities/features/html_features/features_html.yml
+++ b/entities/features/html_features/features_html.yml
@@ -35,6 +35,7 @@
       title: Chrome Platform Status
   tags:
     - features
+    - web-features:details-name
   patterns:
     - accordion
 


### PR DESCRIPTION
This is using the same tagging approach as in BCD:
https://github.com/mdn/browser-compat-data/blob/74547d66328d241c6b7d171adc3cdf7bce8872dd/html/elements/dialog.json#L9