### PR TITLE
Fix titles to make them align with the `Features` table (#1)

### DIFF
--- a/entities/features/html_features/html_graphics.yml
+++ b/entities/features/html_features/html_graphics.yml
@@ -1,5 +1,5 @@
 - id: mapviewer_element
-  name: MapML
+  name: "`<mapviewer>` (Inline MapML)"
   isExperimental: true # proposal/unsupported feature
   description: |
     Embed interactive maps in HTML.
@@ -12,7 +12,7 @@
 
 - id: canvas_colorspace
   webFeaturesId: canvas-2d-color-management
-  name: Color management for 2D canvas
+  name: "`colorSpace` for 2D canvas"
   description: |
     Set the color space for the graphics being drawn on a  `<canvas>` element.
   example:
@@ -23,7 +23,7 @@
 - id: canvas_drawelement
   isExperimental: true # proposal/unsupported feature
   name: |
-    `ctx.drawElement()`
+    `ctx.drawElement()` (HTML in canvas)
   description: |
     Draw an HTML element on `<canvas>`,  with conveniences for redrawing and hit testing.
   example:

--- a/entities/features/html_features/html_main.yml
+++ b/entities/features/html_features/html_main.yml
@@ -6,7 +6,7 @@
 
 - id: accordion_element
   webFeaturesId: details-name
-  name: Exclusive Accordion
+  name: "`<details name>` (Exclusive Accordion)"
   needsTranslation: true
   description:
     Group `<details>` elements so that only up to one in the group can
@@ -476,7 +476,7 @@
 
 - id: dialog_closedby
   webFeaturesId: dialog-closedby
-  name: "`<dialog closedby>`"
+  name: "`<dialog closedby="any">`"
   description: |
     Controls which user actions close a dialog. For example `<dialog closedby="any">` allows the dialog to be closed by clicking outside of it (light dismiss).
 
@@ -503,7 +503,7 @@
 
 - id: element_internals
   webFeaturesId: form-associated-custom-elements
-  name: "`ElementInternals` API"
+  name: "`ElementInternals`"
   needsTranslation: false
   description: Assign hidden semantics to custom elements, facilitating
     accessibility and allowing them to participate fully in forms.
@@ -741,7 +741,7 @@
 
 - id: imperative_slot
   webFeaturesId: slot-assign
-  name: Imperative slot assignment
+  name: '`slotAssignment: "manual"` (Imperative slot assignment)'
   needsTranslation: true
   description: A way to assign elements to slots manually via JS, so that slot
     assignment does not have to be managed by the component consumers.
@@ -881,7 +881,8 @@
     - features
 
 - id: lazy_loading
-  name: Lazy loading
+  name: |
+    `loading="lazy"`
   needsTranslation: true
   description: Load certain resources only when needed.
   example:
@@ -938,7 +939,7 @@
     - features
 
 - id: model_element
-  name: "`<model>` for AR/VR/3D content"
+  name: "`<model>` (Inline AR/VR/3D content)"
   needsTranslation: false
   description: |
     Allows embedding 3D models in HTML with built-in controls.
@@ -1102,7 +1103,7 @@
     - canvas
 
 - id: svg_element
-  name: "`<svg>` (inline SVG)"
+  name: "`<svg>` (Inline SVG)"
   description: Embed SVG vector graphics directly in markup
   example:
     language: html
@@ -1116,7 +1117,7 @@
     - features
 
 - id: math_element
-  name: "`<math>` (inline MathML)"
+  name: "`<math>` (Inline MathML)"
   description: Display math directly in HTML, using MathML.
   example:
     language: html
@@ -1156,7 +1157,7 @@
 
 - id: popover_api
   webFeaturesId: popover
-  name: Popover API
+  name: "`popover` attribute (Popover API)"
   needsTranslation: false
   description: HTML syntax and JS API facilitating popovers such as overlays,
     popups, menus etc.
@@ -1379,7 +1380,7 @@
     - features
 
 - id: sanitizer_api
-  name: Sanitizer API
+  name: "`element.setHTML()` and `Document.parseHTML()` (Sanitizer API)"
   needsTranslation: true
   description: API to prevent XSS attacks by sanitizing untrusted strings of HTML.
   example:
@@ -1775,7 +1776,7 @@
 - id: invokers
   webFeaturesId: invoker-commands
   name: |
-    `command` and `commandfor` attributes (Invokers)
+    `command` and `commandfor` attributes (Command Invokers)
   description: |
     A declarative way for `<button>` to invoke predefined custom commands.
   example:

--- a/entities/features/html_features/html_pwas.yml
+++ b/entities/features/html_features/html_pwas.yml
@@ -97,8 +97,8 @@
     - transition api
 
 - id: web_bluetooth_api
-  webFeaturesId: web-bluetoot
-  name: Web Bluetooth API
+  webFeaturesId: web-bluetooth
+  name: Web Bluetooth
   description: |
     Connect to and communicate with nearby Bluetooth Low Energy (BLE) devices.
   example:
@@ -204,7 +204,7 @@
 
 - id: web_usb_api
   webFeaturesId: webusb
-  name: WebUSB
+  name: Web USB
   description: |
     Directly communicate with USB devices, enabling data exchange without drivers or native apps.
   example:
@@ -215,8 +215,7 @@
 
 - id: payment_request_api
   webFeaturesId: payment-request
-  name: |
-    `PaymentRequest` API
+  name: Payment Request API
   description: |
     Enables a consistent, secure way for websites to request payments using the browser’s native UI.
   example:

--- a/entities/features/html_features/html_system_capabilities.yml
+++ b/entities/features/html_features/html_system_capabilities.yml
@@ -4,7 +4,7 @@
 - id: register_protocol_handler
   webFeaturesId: registerprotocolhandler
   name: |
-    `registerProtocolHandler()`
+    `navigator.registerProtocolHandler()`
   description: |
     Lets a web app register itself as the handler for certain protocols (like `mailto:` or `web+custom:`).
   example:

--- a/entities/features/js_features/js_other.yml
+++ b/entities/features/js_features/js_other.yml
@@ -135,7 +135,7 @@
   caniuse: web-share
 
 - id: webxr
-  name: navigator.xr (WebXR Device API)
+  name: "`navigator.xr` (WebXR Device API)"
   description: |
     Create AR/VR sessions with compatible output devices.
   example:
@@ -497,7 +497,7 @@
 
 - id: web_nfc_api
   webFeaturesId: web-nfc
-  name: Web NFC API
+  name: Web NFC
   description: |
     Read from and write to NFC tags using a device’s built-in NFC reader.
   example:


### PR DESCRIPTION
Changes:

* Sanitizer API

* Exclusive Accordion

* `<dialog closedby="any">`

* Popover API

* Invokers

* Inline SVG

* Inline MathML

* Inline MapML

* `<model>`

* WebXR

* `colorSpace` for 2D canvas

* HTML in canvas

* Lazy loading

* Imperative slot assignment

* `ElementInternals`

* `registerProtocolHandler()`

* Web Bluetooth

* Payment Request API

* Web NFC