### PR TITLE
Reparent gamut_mapping under wide_gamut_colors

### DIFF
--- a/tokens/pain_points/css_pain_points/colors_pain_points.yml
+++ b/tokens/pain_points/css_pain_points/colors_pain_points.yml
@@ -73,7 +73,7 @@
 
 - id: gamut_mapping
   name: Gamut mapping and display variability
-  parentId: color_management
+  parentId: wide_gamut_colors
   descriptionIssues: >
     Handling out-of-gamut colors (especially OKLCH): lack of browser gamut mapping, colors being clamped or made invalid rather than mapped, and preserving intended appearance across gamuts. Colors rendering differently across screens, monitors, and OSes, including HDR/wide-gamut display variability, profiles, and calibration.
 


### PR DESCRIPTION
Changes `gamut_mapping`'s `parentId` from `color_management` to `wide_gamut_colors`.

+1 / -1 loc

🤖 Generated with [Claude Code](https://claude.com/claude-code)