### PR TITLE
Add Formisch to React form libraries

### DIFF
--- a/entities/libraries/react_libraries/react_forms.yml
+++ b/entities/libraries/react_libraries/react_forms.yml
@@ -119,6 +119,14 @@
     - modularform
     - modular form
 
+- id: formisch
+  name: Formisch
+  npm: "@formisch/react"
+  github: open-circle/formisch
+  homepageUrl: https://formisch.dev/
+  tags:
+    - forms
+
 - id: informed
   name: Informed
   github: https://github.com/teslamotors/informed


### PR DESCRIPTION
Adds [Formisch](https://formisch.dev/) to the React form libraries entities. It is the schema-based successor of Modular Forms, which is already listed. I'm the author of both libraries.